### PR TITLE
feat: update PCIDSS Req 8-3.6 control implementation

### DIFF
--- a/markdown/component-definitions/PCIDSS-Component/software-comp/rhel9-pcidss_4-base/pcidss_4_8/pcidss_4_8-3.6.md
+++ b/markdown/component-definitions/PCIDSS-Component/software-comp/rhel9-pcidss_4-base/pcidss_4_8/pcidss_4_8-3.6.md
@@ -10,7 +10,7 @@ x-trestle-global:
   sort-id: pcidss_4_8-03.06
 ---
 
-# pcidss_4_8-3.6 - \[REPLACE_ME\] If Passwords/Passphrases Are Used As Authentication Factors To Meet Requirement 8.3.1, They Meet The Minimum Level Of Complexity.
+# pcidss_4_8-3.6 - \[REPLACE_ME\] If Passwords/Passphrases Are Used As Authentication Factors To Meet Requirement 8.3.1, They Meet The Following Minimum Level Of Complexity.
 
 ## Control Statement
 
@@ -29,6 +29,10 @@ ______________________________________________________________________
 <!-- Note that the list of rules under ### Rules: is read-only and changes will not be captured after assembly to JSON -->
 
 <!-- Add control implementation description here for control: pcidss_4_8-3.6 -->
+
+Requirement 8-3.6 implements the Guideline: "Entities can consider adding increased complexity by requiring the use of special characters and upper- and lower-case characters, in addition to the minimum standards outlined in the requirement." 
+
+The system check rules which apply to Requirement 8-3.6 are automated within the base level and documented in Compliance As Code. 
 
 ### Rules:
 


### PR DESCRIPTION
# Description

This PR updates the control implementation for the `PCI-DSS v4.0.1` Requirement `8-3.6`. The Control Statement was revised to use the precise language from the PCI-DSS standard. 

The Control Implementation section was updated with context on the `ComplianceAsCode/content` that exists as a resource for automatic password length checks, etc.

## Review Hints

* The Component Definition was reviewed in reference to the [PCI-DSS 4.0.1 PDF](https://www.commerce.uwo.ca/pdf/PCI-DSS-v4_0.pdf)
* The `ComplianceAsCode/content` [RHEL9 PCI-DSS Profile](https://github.com/ComplianceAsCode/content/blob/master/products/rhel9/profiles/pci-dss.profile) which ensures Red Hat Enterprise Linux 9 is configured in alignment with `PCI-DSS v4.0.1` requirements.